### PR TITLE
add tcdc_aveclm to SCM output

### DIFF
--- a/scm/etc/scripts/gmtb_scm_analysis.py
+++ b/scm/etc/scripts/gmtb_scm_analysis.py
@@ -299,6 +299,7 @@ lw_dn_sfc_tot = []
 lw_dn_sfc_clr = []
 rh = []
 rh_500 = []
+tcdc_aveclm = []
 
 inst_time_group = []
 diag_time_group = []
@@ -732,6 +733,14 @@ for i in range(len(gmtb_scm_datasets)):
     
     sfc_rad_net_ocean.append((sfc_dwn_sw[-1] - sfc_up_sw[-1]) + (sfc_dwn_lw[-1] - sfc_up_lw_ocean[-1]))
     inst_time_group.append('sfc_rad_net_ocean')
+    
+    try:
+        tcdc_aveclm.append(nc_fid.variables['tcdc_aveclm'][:])
+    except KeyError:
+        print('tcdc_aveclm not in the output file {0}'.format(gmtb_scm_datasets[i]))
+        print('Missing variables are replaced with {0}'.format(missing_value))
+        tcdc_aveclm.append(missing_value*np.ones((len(time_swrad[-1]))))
+    swrad_time_group.append('tcdc_aveclm')
     
     # sw_up_TOA_tot.append(nc_fid.variables['sw_up_TOA_tot'][:])
     # sw_dn_TOA_tot.append(nc_fid.variables['sw_dn_TOA_tot'][:])

--- a/scm/etc/scripts/plot_configs/all_vars_test_twpice.ini
+++ b/scm/etc/scripts/plot_configs/all_vars_test_twpice.ini
@@ -10,6 +10,9 @@ time_series_resample = True
   [[active]]
     start = 2006, 1, 20, 0
     end = 2006, 1, 25, 12
+  [[suppressed]]
+    start = 2006, 1, 28, 0
+    end = 2006, 2, 2, 12
 
 [time_snapshots]
 
@@ -103,9 +106,9 @@ time_series_resample = True
   [[profiles_instant]]
 
   [[time_series]]
-    vars = pres_s, lhf, shf , T_s , tprcp_inst, tprcp_rate_inst, tau_u, tau_v, pwat, sfc_net_sw, tprcp_rate_accum
-    vars_labels = 'surface pressure','sfc latent heat flux ($W$ $m^{-2}$)','sfc sensible heat flux ($W$ $m^{-2}$)','surface forcing temperature (K)','instantaneous LWE total precipitation ($m$)','instantaneous LWE total precipitation rate ($mm$ $h^{-1}$)','sfc u stress ($Pa$)','sfc v stress ($Pa$)','precipitable water ($cm$)', 'sfc net SW (total) ($W$ $m^{-2}$)', 'accumulated total precipitation rate ($mm$ $h^{-1}$)'
-    conversion_factor = 1.0, 1.0, 1.0, 1.0, 1.0, 3.6E6, 1.0, 1.0, 0.1, 1.0, 3.6E6
+    vars = pres_s, lhf, shf , T_s , tprcp_inst, tprcp_rate_inst, tau_u, tau_v, pwat, sfc_net_sw, tprcp_rate_accum, tcdc_aveclm
+    vars_labels = 'surface pressure','sfc latent heat flux ($W$ $m^{-2}$)','sfc sensible heat flux ($W$ $m^{-2}$)','surface forcing temperature (K)','instantaneous LWE total precipitation ($m$)','instantaneous LWE total precipitation rate ($mm$ $h^{-1}$)','sfc u stress ($Pa$)','sfc v stress ($Pa$)','precipitable water ($cm$)', 'sfc net SW (total) ($W$ $m^{-2}$)', 'accumulated total precipitation rate ($mm$ $h^{-1}$)','column total cloud cover (%)'
+    conversion_factor = 1.0, 1.0, 1.0, 1.0, 1.0, 3.6E6, 1.0, 1.0, 0.1, 1.0, 3.6E6, 1.0
     
   [[time_series_multi]]
     [[[soil_T]]]


### PR DESCRIPTION
- added new output variable from Diag DDT (valid on swrad interval); note that the fluxr(:,17) variable is multiplied by the radiation timestep, so one MUST do time-averaging in the output routine to get a real value (or else divide by the radiation timestep in post-processing)
- added new output_append subroutine to handle variables on the swrad interval from the Diag DDT and added the new variable to it
- added code in gmtb_scm_analysis.py to be able to plot the new variable
- added a few lines to the TWPICE case plotting script to plot the new variable for testing