### PR TITLE
For FV3LAM-derived SCM cases, use column_area specified in the case namelist file

### DIFF
--- a/scm/src/gmtb_scm_input.F90
+++ b/scm/src/gmtb_scm_input.F90
@@ -30,6 +30,7 @@ contains
 !! requires that the compiler supports this standard.
 subroutine get_config_nml(scm_state)
   use gmtb_scm_type_defs, only : scm_state_type
+  use NetCDF_read, only: missing_value
 
   type(scm_state_type), target, intent(inout) :: scm_state
 
@@ -121,6 +122,7 @@ subroutine get_config_nml(scm_state)
   day = 19
   hour = 3
   min = 0
+  column_area = missing_value
   input_type = 0
   
   open(unit=10, file=experiment_namelist, status='old', action='read', iostat=ioerror)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
For FV3LAM-derived SCM cases, modify code so that if column_area is specified in the case namelist file, it is used in the SCM run instead of being overwritten by the area specified in the FV3LAM grid file.  If column_area is not specified in the case namelist file, the one from the FV3LAM grid file is used (which is what currently happens regardless of whether or not column_area is specified in the namelist file).

With this approach, the user doesn't have to create a new SCM case for every new column_area that is different than the one specified in the FV3LAM run.

## TESTS CONDUCTED: 
Printed out the value of scm_state%area(i) in the set_state subroutine, and it changes as expected according to the column_area value in the case namelist file.
